### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,7 @@ Find and replace all on all files (CMD+SHIFT+F):
 1. Add `@ant-design-vue/nuxt` dependency to your project
 
 ```bash
-# Using pnpm
 npx nuxi@latest module add ant-design-vue
-
-# Using yarn
-npx nuxi@latest module add ant-design-vue
-
-# Using npm
 npx nuxi@latest module add ant-design-vue
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ Find and replace all on all files (CMD+SHIFT+F):
 
 ```bash
 # Using pnpm
-pnpm add -D @ant-design-vue/nuxt
+npx nuxi@latest module add ant-design-vue
 
 # Using yarn
-yarn add --dev @ant-design-vue/nuxt
+npx nuxi@latest module add ant-design-vue
 
 # Using npm
-npm install --save-dev @ant-design-vue/nuxt
+npx nuxi@latest module add ant-design-vue
 ```
 
 2. Add `@ant-design-vue/nuxt` to the `modules` section of `nuxt.config.ts`

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ Find and replace all on all files (CMD+SHIFT+F):
 
 ```bash
 npx nuxi@latest module add ant-design-vue
-npx nuxi@latest module add ant-design-vue
 ```
 
 2. Add `@ant-design-vue/nuxt` to the `modules` section of `nuxt.config.ts`


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
